### PR TITLE
Chuck's various edits to voter firmware for GPS date fix and for smart ID when offline

### DIFF
--- a/board-firmware/src/HardwareProfile.h
+++ b/board-firmware/src/HardwareProfile.h
@@ -61,7 +61,7 @@ extern char dummy_loc;
 #define SMT_BOARD
 #endif
 
-// #define CHUCK
+#define CHUCK
 
 #if	defined CHUCK
 #define	CHUCK_SQUELCH

--- a/board-firmware/src/TCPIP Stack/StackTsk.h
+++ b/board-firmware/src/TCPIP Stack/StackTsk.h
@@ -54,6 +54,7 @@
  								EEPROM_BUFFER_SIZE, USE_LCD
  * Howard Schlunder		8/09/06	Removed MCHP_MAC, added STACK_USE_NBNS, 
  *								STACK_USE_DNS, and STACK_USE_GENERIC_TCP_EXAMPLE
+ * Chuck Henderson WB9UUS 3/3/2019 Added DateFix storage
  ********************************************************************/
 #ifndef __STACK_TSK_H
 #define __STACK_TSK_H
@@ -162,7 +163,8 @@ typedef struct __attribute__((__packed__))
 	BOOL EthFullDuplex;
 	WORD LaunchDelay;
 	WORD CTCSSThreshold;
-	BYTE Zeros[564];
+	BYTE DateFix;
+	BYTE Zeros[563];
 } APP_CONFIG;
 
 #ifndef THIS_IS_STACK_APPLICATION

--- a/board-firmware/src/TCPIP Stack/StackTsk.h
+++ b/board-firmware/src/TCPIP Stack/StackTsk.h
@@ -163,8 +163,8 @@ typedef struct __attribute__((__packed__))
 	BOOL EthFullDuplex;
 	WORD LaunchDelay;
 	WORD CTCSSThreshold;
-	BYTE DateFix;
-	BYTE Zeros[563];
+	DWORD DateFix;
+	BYTE Zeros[560];
 } APP_CONFIG;
 
 #ifndef THIS_IS_STACK_APPLICATION

--- a/board-firmware/src/TCPIP Stack/StackTsk.h
+++ b/board-firmware/src/TCPIP Stack/StackTsk.h
@@ -163,8 +163,8 @@ typedef struct __attribute__((__packed__))
 	BOOL EthFullDuplex;
 	WORD LaunchDelay;
 	WORD CTCSSThreshold;
-	DWORD DateFix;
-	BYTE Zeros[560];
+	BYTE DateFix;
+	BYTE Zeros[563];
 } APP_CONFIG;
 
 #ifndef THIS_IS_STACK_APPLICATION

--- a/board-firmware/src/Voter.c
+++ b/board-firmware/src/Voter.c
@@ -4676,7 +4676,7 @@ static void OffLineMenu()
 		}
 		printf(" \n");
 		sel = atoi(cmdstr);
-		if ((sel >= 1) && (sel <= 11))
+		if ((sel >= 1) && (sel <= 12))
 		{
 			printf(entnewval);
 			if (aborted) continue;

--- a/board-firmware/src/Voter.c
+++ b/board-firmware/src/Voter.c
@@ -2368,9 +2368,9 @@ extern float doubleify(BYTE *p);
 				tm.tm_mon = twoascii(strs[9] + 2) - 1;
 			tm.tm_year = twoascii(strs[9] + 4) + 100;
 			if (AppConfig.DebugLevel & 64)
-				gps_time = (DWORD) mktime(&tm) + (AppConfig.DateFix * 619315200) + 1;
+				gps_time = (DWORD) mktime(&tm) + ((DWORD) AppConfig.DateFix * 619315200) + 1;
 			else
-				gps_time = (DWORD) mktime(&tm) + (AppConfig.DateFix * 619315200);
+				gps_time = (DWORD) mktime(&tm) + ((DWORD) AppConfig.DateFix * 619315200);
 			if (AppConfig.DebugLevel & 32)
 #ifdef CHUCK
 				printf("GPS-DEBUG: mon: %d, gps_time: %ld, real_time: %ld, ctime: %s\n",tm.tm_mon,gps_time,real_time,ctime((time_t *)&gps_time));
@@ -2449,7 +2449,7 @@ extern float doubleify(BYTE *p);
 				tm.tm_mon = gps_buf[15] - 1; 
 			w = gps_buf[17] | ((WORD)gps_buf[16] << 8);
 			tm.tm_year = w - 1900;
-			gps_time = (DWORD) mktime(&tm) + (AppConfig.DateFix * 619315200);
+			gps_time = (DWORD) mktime(&tm) + ((DWORD) AppConfig.DateFix * 619315200);
 			if (!USE_PPS) system_time.vtime_sec = timing_time = gps_time + 1;
 			return;
 		}

--- a/board-firmware/src/Voter.c
+++ b/board-firmware/src/Voter.c
@@ -2449,7 +2449,7 @@ extern float doubleify(BYTE *p);
 				tm.tm_mon = gps_buf[15] - 1; 
 			w = gps_buf[17] | ((WORD)gps_buf[16] << 8);
 			tm.tm_year = w - 1900;
-			gps_time = (DWORD) mktime(&tm) + 619315200;
+			gps_time = (DWORD) mktime(&tm) + (AppConfig.DateFix * 619315200);
 			if (!USE_PPS) system_time.vtime_sec = timing_time = gps_time + 1;
 			return;
 		}
@@ -4631,6 +4631,8 @@ static void OffLineMenu()
 		"9  - Offline CTCSS Tone (%.1f) Hz\n"
 		"10 - Offline CTCSS Level (0-32767) (%d)\n"
 		"11 - Offline De-Emphasis Override (0=NORMAL, 1=OVERRIDE) (%d)\n",
+	 	menu1b[] = 
+	 	"12 - GPS DateFix (0=NORMAL, 1=+19.7 years, 2=+39.4 years) (%d)\n",
 		menu2[] = 
 		"99 - Save Values to EEPROM\n"
 		"x  - Exit OffLine Mode Parameter Menu (back to main menu)\nq  - Disconnect Remote Console Session, r - reboot system\n\n",
@@ -4644,6 +4646,8 @@ static void OffLineMenu()
 		printf(menu1a,(double)AppConfig.CTCSSTone,AppConfig.CTCSSLevel,AppConfig.OffLineNoDeemp);
 		main_processing_loop();
 		secondary_processing_loop();
+	 	printf(menu1b,AppConfig.DateFix);
+	 	main_processing_loop();
 		printf(menu2);
 		fflush(stdout);
 		aborted = 0;
@@ -4770,6 +4774,13 @@ static void OffLineMenu()
 				if ((sscanf(cmdstr,"%u",&i1) == 1) && (i1 <= 1))
 				{
 					AppConfig.OffLineNoDeemp = i1;
+					ok = 1;
+				}
+				break;
+			case 12: // GPS DateFix
+				if ((sscanf(cmdstr,"%u",&i1) == 1) && (i1 <= 2))
+				{
+					AppConfig.DateFix = i1;
 					ok = 1;
 				}
 				break;
@@ -5791,6 +5802,7 @@ static void InitAppConfig(void)
 	AppConfig.CTCSSLevel = 3000;
 	AppConfig.PPSPolarity = 2;
 	AppConfig.FailTime = 6000;
+	AppConfig.DateFix = 0;
 
 	#if defined(EEPROM_CS_TRIS)
 	{

--- a/board-firmware/src/Voter.c
+++ b/board-firmware/src/Voter.c
@@ -2368,9 +2368,9 @@ extern float doubleify(BYTE *p);
 				tm.tm_mon = twoascii(strs[9] + 2) - 1;
 			tm.tm_year = twoascii(strs[9] + 4) + 100;
 			if (AppConfig.DebugLevel & 64)
-				gps_time = (DWORD) mktime(&tm) + 1;
+				gps_time = (DWORD) mktime(&tm) + (AppConfig.DateFix * 619315200) + 1;
 			else
-				gps_time = (DWORD) mktime(&tm);
+				gps_time = (DWORD) mktime(&tm) + (AppConfig.DateFix * 619315200);
 			if (AppConfig.DebugLevel & 32)
 #ifdef CHUCK
 				printf("GPS-DEBUG: mon: %d, gps_time: %ld, real_time: %ld, ctime: %s\n",tm.tm_mon,gps_time,real_time,ctime((time_t *)&gps_time));

--- a/board-firmware/src/Voter.c
+++ b/board-firmware/src/Voter.c
@@ -5784,12 +5784,13 @@ static void InitAppConfig(void)
 	AppConfig.CWSpeed = 400;
 	AppConfig.CWBeforeTime = 4000;
 	AppConfig.CWAfterTime = 4000;
-	strcpy((char *)AppConfig.FailString,"OFF LINE");
-	strcpy((char *)AppConfig.UnFailString,"OK");
+	strcpy((char *)AppConfig.FailString,"WZ9ZZZ /R");
+	strcpy((char *)AppConfig.UnFailString,"E");
 	AppConfig.HangTime = 15;
 	AppConfig.CTCSSTone = 0.0;
 	AppConfig.CTCSSLevel = 3000;
 	AppConfig.PPSPolarity = 2;
+	AppConfig.FailTime = 6000;
 
 	#if defined(EEPROM_CS_TRIS)
 	{

--- a/board-firmware/src/Voter.c
+++ b/board-firmware/src/Voter.c
@@ -2370,7 +2370,7 @@ extern float doubleify(BYTE *p);
 			if (AppConfig.DebugLevel & 64)
 				gps_time = (DWORD) mktime(&tm) + ((DWORD) AppConfig.DateFix * 619315200) + 1;
 			else
-				gps_time = (DWORD) mktime(&tm) + ((DWORD) AppConfig.DateFix * 619315200);
+				gps_time = (DWORD) mktime(&tm) + 619315200;
 			if (AppConfig.DebugLevel & 32)
 #ifdef CHUCK
 				printf("GPS-DEBUG: mon: %d, gps_time: %ld, real_time: %ld, ctime: %s\n",tm.tm_mon,gps_time,real_time,ctime((time_t *)&gps_time));


### PR DESCRIPTION
Trying to submit all of the various changes I have made to the voter firmware that includes various fixes for the GPS date, including the latest fix for old Garmin pucs that had a date from 20 years ago.  These changes also include a smart ID for when offline.  More changes to come for GPS date rollover issues and for other minor features. 